### PR TITLE
fix: center footer on mobile, add visible dot separators, increase spacing

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -81,9 +81,10 @@
 
 /* ── Footer ── */
 .site-footer {
-    margin-top: 40px;
-    padding: 20px 0;
-    border-top: 1px solid #e0e0e0;
+    margin-top: 60px;
+    padding: 24px 0 20px;
+    border-top: 1px solid #ddd;
+    text-align: center;
     font-size: 13px;
     color: #777;
 }
@@ -97,28 +98,20 @@
 .site-footer a:hover,
 .site-footer a:focus {
     color: #2c3e50;
+    text-decoration: underline;
 }
 
 .footer-links {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 8px;
-    margin-bottom: 10px;
+    line-height: 1.8;
 }
 
-.footer-links a::after {
-    content: "·";
-    margin-left: 8px;
-    color: #bbb;
-}
-
-.footer-links a:last-child::after {
-    content: none;
+.footer-links .sep {
+    color: #ccc;
+    margin: 0 6px;
 }
 
 .footer-doi {
-    text-align: center;
+    margin-top: 8px;
     font-size: 12px;
     color: #999;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -56,10 +56,7 @@
     <footer class="site-footer">
         <div class="container">
             <div class="footer-links">
-                <a href="{{ url_for('public.home') }}" data-i18n="footer_copy">Archives World Map</a>
-                <a href="https://feudo.org" target="_blank">Feudo.org</a>
-                <a href="https://labhd.ufba.br" target="_blank">LABHDUFBA</a>
-                <a href="https://github.com/rsandrade/archives-worldmap" target="_blank">GitHub</a>
+                <a href="{{ url_for('public.home') }}" data-i18n="footer_copy">Archives World Map</a><span class="sep"> · </span><a href="https://feudo.org" target="_blank">Feudo.org</a><span class="sep"> · </span><a href="https://labhd.ufba.br" target="_blank">LABHDUFBA</a><span class="sep"> · </span><a href="https://github.com/rsandrade/archives-worldmap" target="_blank">GitHub</a>
             </div>
             <div class="footer-doi">
                 <span data-i18n="footer_doi_label">DOI</span>


### PR DESCRIPTION
Corrige o rodapé no mobile:

- **Centralizado** em vez de alinhado à esquerda (text-align: center)
- **Separadores · visíveis** entre links (usando `<span>` ao invés de `::after` + flex, que não funcionava direito no mobile)
- **Mais espaço** acima do footer (margin-top: 60px) para separar do campo de busca
- **Padding aumentado** para respiro visual

Antes:
- Layout flex com gap + ::after (separadores invisíveis no mobile)
- Alinhado à esquerda
- Muito próximo ao conteúdo acima